### PR TITLE
feat (#2): adicionar pagina para cadastro de fazenda

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,7 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     AppFooter: typeof import('./components/AppFooter.vue')['default']
+    CadastroFazenda: typeof import('./components/CadastroFazenda.vue')['default']
     CadastroTalhao: typeof import('./components/CadastroTalhao.vue')['default']
     Footer: typeof import('./components/Footer.vue')['default']
     HelloWorld: typeof import('./components/HelloWorld.vue')['default']

--- a/src/components/CadastroFazenda.vue
+++ b/src/components/CadastroFazenda.vue
@@ -1,0 +1,164 @@
+<template>
+	<div class="d-flex flex-column ga-4 pa-2">
+		<div class="text-h2"> Fazendas </div>
+		<v-form class="elevation-5" :disabled="loading">
+			
+			<v-container>
+				<v-progress-linear v-if="loading" indeterminate />
+				<v-row class="text-body-1">
+					<v-col cols="12">
+						Cadastrar nova fazenda
+					</v-col>
+				</v-row>
+				<v-row>
+					<v-col cols="12">
+						<v-text-field label="Nome da fazenda" v-model:model-value="nome" />
+					</v-col>
+				</v-row>
+				<v-row>
+					<v-col cols="4">
+						<v-number-input label="Produção anual" control-variant="stacked" v-model:model-value="prodAnual" />
+					</v-col>
+					<v-col cols="4">
+						<v-number-input label="Area" control-variant="stacked" v-model:model-value="area" />
+					</v-col>
+					<v-col cols="4">
+						<v-text-field label="Tipo de solo" v-model:model-value="solo" />
+					</v-col>
+				</v-row>
+				<v-row>
+					<v-col cols="6">
+						<v-autocomplete
+							label="Cidade"
+								:items="[...cityList, newCity].map((city) => ({
+								title: `${city.nome}${city?.estado?.nome ? ` (${city.estado.nome})`: ''}`,
+								value: city
+							}))"
+							@update:search="(v) => {
+								newCity.nome = v
+							}"
+							v-model:model-value="selectedCity"
+						/>
+					</v-col>
+					<v-col cols="6">
+						<v-autocomplete
+							label="Estado"
+							:disabled="selectedCity?.id !== null"
+							v-model:model-value="selectedState"
+							:items="stateList.map(state => ({
+								title: state.nome,
+								value: state
+							}))"
+							@update:model-value="(v) => newCity.estado = { id: v.id }"
+						/>
+					</v-col>
+				</v-row>
+				<div class="d-flex ga-4">
+					<v-btn :disabled="!valid" color="deep-purple-darken-1" @click="postFazenda">
+						Submit
+					</v-btn>
+					<v-btn @click="clear">
+						Clear
+					</v-btn>
+				</div>
+			</v-container>
+		</v-form>
+	</div>
+</template>
+
+<script setup lang="ts">
+import router from '@/router';
+import axios from 'axios'
+import { VNumberInput } from 'vuetify/labs/components';
+
+type State = {
+	id: number | null
+	nome?: string
+	sigla?: string
+}
+
+type City = {
+	id: number | null
+	nome: string
+	estado: State | null
+}
+
+const cityList = ref<City[]>([])
+const newCity = ref<City>({
+	id: null,
+	nome: '',
+	estado: null
+})
+
+const stateList = ref<State[]>([])
+const selectedCity = ref<City | null>(null)
+const selectedState = ref<State | null>(null)
+
+const nome = ref<string>('')
+const prodAnual = ref<number>(0)
+const area = ref<number>(0)
+const solo = ref<string>('')
+
+const loading = ref(true)
+const valid = computed(() =>
+	nome.value !== '' &&
+	solo.value !== '' &&
+	selectedCity.value !== null &&
+	selectedState.value !== null
+)
+
+const fetchCityList = async () => {
+	const result = await axios.get('http://localhost:8080/cidade/all')
+	cityList.value = result.data
+}
+
+const fetchStateList = async () => {
+	const result = await axios.get('http://localhost:8080/estado/all')
+	stateList.value = result.data
+}
+
+const postFazenda = async () => {
+	const body = {
+		nome: nome.value,
+		prodAnual: prodAnual.value,
+		area: area.value,
+		tipoSolo: solo.value,
+		cidade: selectedCity.value
+	}
+
+	loading.value = true
+	await axios.post('http://localhost:8080/fazenda', body)
+
+	loading.value = false
+
+	router.push('/fazenda/')
+}
+
+const clear = () => {
+	selectedCity.value = null
+	selectedState.value = null
+	nome.value = ''
+	prodAnual.value = 0
+	area.value = 0
+	solo.value = ''
+}
+
+watch(selectedCity, () => {
+	if(selectedCity.value) {
+		selectedState.value = selectedCity.value.estado
+	}
+
+	if(selectedCity.value !== newCity.value) {
+		newCity.value.nome = ''
+	} else {
+		selectedState.value = null
+	}
+
+})
+
+onMounted(async () => {
+	await fetchCityList()
+	await fetchStateList()
+	loading.value = false
+})
+</script>

--- a/src/components/ListagemFazendas.vue
+++ b/src/components/ListagemFazendas.vue
@@ -4,7 +4,7 @@
     <v-data-table-server
       v-model:items-per-page="itensPorPagina"
       :headers="headers"
-      :items="paginaFazenda"
+      :items="fazendas"
       :items-length="totalFazendas"
       :loading="loading"
       item-value="fazNome"
@@ -43,22 +43,23 @@ const headers = ref([
 
 const fazendas = ref([]);
 const itensPorPagina = ref(5);
-const paginaFazenda = ref([]);
 const totalFazendas = ref(0);
 const loading = ref(true);
 
-async function buscarFazenda(page = 0, size = 5) {
+async function buscarFazenda(page = 1, size = 5) {
   loading.value = true;
 
-  try {
-    const response = await axios.get(
-      "http://localhost:8080/fazenda/listar/{page}/{quantity}"
-    );
+  console.log(page, size)
 
+  try {
+    console.log(
+      `http://localhost:8080/fazenda/listar/${page}/${size}`)
+    const response = await axios.get(
+      `http://localhost:8080/fazenda/listar/${page}/${size}`
+    );
     fazendas.value = response.data.content;
     totalFazendas.value = response.data.totalElements || 0;
 
-    carregarFazendas({ page: 1, itemsPerPage: size });
   } catch (error) {
     console.error("Erro ao buscar fazendas:", error);
   } finally {
@@ -67,13 +68,8 @@ async function buscarFazenda(page = 0, size = 5) {
 }
 
 function carregarFazendas({ page, itemsPerPage }) {
-  loading.value = true;
-  setTimeout(() => {
-    const inicio = (page - 1) * itemsPerPage;
-    const fim = inicio + itemsPerPage;
-    paginaFazenda.value = fazendas.value.slice(inicio, fim);
-    loading.value = false;
-  }, 500);
+  console.log(page, itemsPerPage)
+  buscarFazenda(page - 1, itemsPerPage)
 }
 
 function editarFazenda(item) {

--- a/src/components/ListagemFazendas.vue
+++ b/src/components/ListagemFazendas.vue
@@ -23,7 +23,7 @@
   </v-container>
 
   <v-container class="d-flex justify-end">
-    <v-btn @click="adicionarFazenda" color="deep-purple-darken-1">
+    <v-btn to="/fazenda/cadastro" color="deep-purple-darken-1">
       Cadastrar Nova Fazenda
     </v-btn>
   </v-container>
@@ -74,10 +74,6 @@ function carregarFazendas({ page, itemsPerPage }) {
     paginaFazenda.value = fazendas.value.slice(inicio, fim);
     loading.value = false;
   }, 500);
-}
-
-function adicionarFazenda() {
-  console.log("Fazenda adicionada");
 }
 
 function editarFazenda(item) {

--- a/src/pages/fazenda/cadastro.vue
+++ b/src/pages/fazenda/cadastro.vue
@@ -1,0 +1,7 @@
+<template>
+	<v-responsive class="align-centerfill-height mx-auto my-10" max-width="900">
+		<cadastro-fazenda />
+	</v-responsive>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/typed-router.d.ts
+++ b/src/typed-router.d.ts
@@ -20,6 +20,7 @@ declare module 'vue-router/auto-routes' {
   export interface RouteNamedMap {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>,
     '/fazenda/': RouteRecordInfo<'/fazenda/', '/fazenda', Record<never, never>, Record<never, never>>,
+    '/fazenda/cadastro': RouteRecordInfo<'/fazenda/cadastro', '/fazenda/cadastro', Record<never, never>, Record<never, never>>,
     '/talhao/': RouteRecordInfo<'/talhao/', '/talhao', Record<never, never>, Record<never, never>>,
   }
 }


### PR DESCRIPTION
Nesse PR foi criado a pagina para cadastro de fazenda e modificado o link de `cadastrar nova fazenda` na pagina de listar para redirecionar a pagina de cadastro.

## Funcionamento
- Botão clear limpa todos os campos e reseta area / produção anual para 0;
- Botão Submit é liberado quando todos os campos tiverem preenchidos;
- Caso exista a cidade, o campo de estado será bloqueado e auto preenchido;
- Caso não exista a cidade, é possivel adicionar o nome da cidade e selecionar o estado.

Close #2